### PR TITLE
Remove PENDING state from relayerApiOrderResponse schema

### DIFF
--- a/schemas/relayer_api_fees_payload_schema.ts
+++ b/schemas/relayer_api_fees_payload_schema.ts
@@ -4,10 +4,10 @@ export const relayerApiFeesPayloadSchema = {
     properties: {
         maker: {$ref: '/Address'},
         taker: {$ref: '/Address'},
-        makerToken: {$ref: '/Address'},
-        takerToken: {$ref: '/Address'},
+        makerTokenAddress: {$ref: '/Address'},
+        takerTokenAddress: {$ref: '/Address'},
         makerTokenAmount: {$ref: '/Number'},
         takerTokenAmount: {$ref: '/Number'},
     },
-    required: ['makerToken', 'takerToken', 'makerTokenAmount', 'takerTokenAmount'],
+    required: ['makerTokenAddress', 'takerTokenAddress', 'makerTokenAmount', 'takerTokenAmount'],
 };

--- a/schemas/relayer_api_order_response_schema.ts
+++ b/schemas/relayer_api_order_response_schema.ts
@@ -10,7 +10,7 @@ export const relayerApiOrderResponseSchema = {
     properties: {
         signedOrder: {$ref: '/SignedOrder'},
         state: {
-            enum: ['OPEN', 'EXPIRED', 'CLOSED', 'UNFUNDED', 'PENDING'],
+            enum: ['OPEN', 'EXPIRED', 'CLOSED', 'UNFUNDED'],
         },
         pending: {
             type: 'object',

--- a/schemas/relayer_api_token_pairs_response_schema.ts
+++ b/schemas/relayer_api_token_pairs_response_schema.ts
@@ -17,9 +17,9 @@ export const relayerApiTokenTradeInfoSchema = {
     properties: {
         address: {$ref: '/Address'},
         symbol: {type: 'string'},
-        precision: {type: 'number'},
+        decimals: {type: 'number'},
         minAmount: {$ref: '/Number'},
         maxAmount: {$ref: '/Number'},
     },
-    required: ['address', 'symbol', 'precision'],
+    required: ['address', 'symbol', 'decimals'],
 };

--- a/test/schema_test.ts
+++ b/test/schema_test.ts
@@ -657,14 +657,14 @@ describe('Schema', () => {
                         tokenA: {
                             address: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
                             symbol: 'MKR',
-                            precision: 18,
+                            decimals: 18,
                             minAmount: '0',
                             maxAmount: '10000000000000000000',
                         },
                         tokenB: {
                             address: '0xef7fff64389b814a946f3e92105513705ca6b990',
                             symbol: 'GLM',
-                            precision: 18,
+                            decimals: 18,
                             minAmount: '0',
                             maxAmount: '50000000000000000000',
                         },
@@ -675,12 +675,12 @@ describe('Schema', () => {
                         tokenA: {
                             address: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
                             symbol: 'MKR',
-                            precision: 18,
+                            decimals: 18,
                         },
                         tokenB: {
                             address: '0xef7fff64389b814a946f3e92105513705ca6b990',
                             symbol: 'GLM',
-                            precision: 18,
+                            decimals: 18,
                         },
                     },
                 ],
@@ -695,12 +695,12 @@ describe('Schema', () => {
                         tokenA: {
                             address: checksummedAddress,
                             symbol: 'MKR',
-                            precision: 18,
+                            decimals: 18,
                         },
                         tokenB: {
                             address: checksummedAddress,
                             symbol: 'GLM',
-                            precision: 18,
+                            decimals: 18,
                         },
                     },
                 ],
@@ -709,12 +709,12 @@ describe('Schema', () => {
                         tokenA: {
                             address: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
                             symbol: 'MKR',
-                            precision: '18',
+                            decimals: '18',
                         },
                         tokenB: {
                             address: '0xef7fff64389b814a946f3e92105513705ca6b990',
                             symbol: 'GLM',
-                            precision: '18',
+                            decimals: '18',
                         },
                     },
                 ],
@@ -735,14 +735,14 @@ describe('Schema', () => {
                         tokenA: {
                             address: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
                             symbol: 'MKR',
-                            precision: 18,
+                            decimals: 18,
                             minAmount: 0,
                             maxAmount: 10000000000000000000,
                         },
                         tokenB: {
                             address: '0xef7fff64389b814a946f3e92105513705ca6b990',
                             symbol: 'GLM',
-                            precision: 18,
+                            decimals: 18,
                             minAmount: 0,
                             maxAmount: 50000000000000000000,
                         },

--- a/test/schema_test.ts
+++ b/test/schema_test.ts
@@ -559,23 +559,23 @@ describe('Schema', () => {
         it('should validate valid fees payloads', () => {
             const testCases = [
                 {
-                    makerToken: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
-                    takerToken: '0xef7fff64389b814a946f3e92105513705ca6b990',
+                    makerTokenAddress: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
+                    takerTokenAddress: '0xef7fff64389b814a946f3e92105513705ca6b990',
                     makerTokenAmount: '10000000000000000000',
                     takerTokenAmount: '30000000000000000000',
                 },
                 {
                     maker: '0x9e56625509c2f60af937f23b7b532600390e8c8b',
                     taker: '0xa2b31dacf30a9c50ca473337c01d8a201ae33e32',
-                    makerToken: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
-                    takerToken: '0xef7fff64389b814a946f3e92105513705ca6b990',
+                    makerTokenAddress: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
+                    takerTokenAddress: '0xef7fff64389b814a946f3e92105513705ca6b990',
                     makerTokenAmount: '10000000000000000000',
                     takerTokenAmount: '30000000000000000000',
                 },
                 {
                     maker: '0x9e56625509c2f60af937f23b7b532600390e8c8b',
-                    makerToken: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
-                    takerToken: '0xef7fff64389b814a946f3e92105513705ca6b990',
+                    makerTokenAddress: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
+                    takerTokenAddress: '0xef7fff64389b814a946f3e92105513705ca6b990',
                     makerTokenAmount: '10000000000000000000',
                     takerTokenAmount: '30000000000000000000',
                 },
@@ -587,20 +587,20 @@ describe('Schema', () => {
             const testCases = [
                 {},
                 {
-                    takerToken: '0xef7fff64389b814a946f3e92105513705ca6b990',
+                    takerTokenAddress: '0xef7fff64389b814a946f3e92105513705ca6b990',
                     makerTokenAmount: '10000000000000000000',
                     takerTokenAmount: '30000000000000000000',
                 },
                 {
                     taker: checksummedAddress,
-                    makerToken: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
-                    takerToken: '0xef7fff64389b814a946f3e92105513705ca6b990',
+                    makerTokenAddress: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
+                    takerTokenAddress: '0xef7fff64389b814a946f3e92105513705ca6b990',
                     makerTokenAmount: '10000000000000000000',
                     takerTokenAmount: '30000000000000000000',
                 },
                 {
-                    makerToken: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
-                    takerToken: '0xef7fff64389b814a946f3e92105513705ca6b990',
+                    makerTokenAddress: '0x323b5d4c32345ced77393b3530b1eed0f346429d',
+                    takerTokenAddress: '0xef7fff64389b814a946f3e92105513705ca6b990',
                     makerTokenAmount: 10000000000000000000,
                     takerTokenAmount: 30000000000000000000,
                 },

--- a/test/schema_test.ts
+++ b/test/schema_test.ts
@@ -386,7 +386,7 @@ describe('Schema', () => {
                         },
                         {
                             signedOrder,
-                            state: 'PENDING',
+                            state: 'OPEN',
                             pending: {
                                 fillAmount: '100000000000000000',
                                 cancelAmount: '100000000000000000',
@@ -411,7 +411,7 @@ describe('Schema', () => {
                         },
                         {
                             signedOrder,
-                            state: 'PENDING',
+                            state: 'OPEN',
                             pending: {
                                 fillAmount: 100000000000000000,
                             },
@@ -436,7 +436,7 @@ describe('Schema', () => {
                         [
                             {
                                 signedOrder,
-                                state: 'PENDING',
+                                state: 'OPEN',
                                 pending: {
                                     fillAmount: '100000000000000000',
                                     cancelAmount: '100000000000000000',
@@ -466,7 +466,7 @@ describe('Schema', () => {
                         [
                             {
                                 signedOrder,
-                                state: 'PENDING',
+                                state: 'OPEN',
                                 pending: {
                                     fillAmount: 100000000000000000,
                                 },


### PR DESCRIPTION
- Removes PENDING state from order response
- Rename `makerToken` and `takerToken` to `makerTokenAddress` and `takerTokenAddress`
- Rename `precision` to `decimals` 